### PR TITLE
Colorize status in output

### DIFF
--- a/scim2_tester/checker.py
+++ b/scim2_tester/checker.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
     parser.add_argument("host")
     parser.add_argument("--token", required=False)
     parser.add_argument("--verbose", required=False, action="store_true")
+    parser.add_argument("--no-color", required=False, action="store_true")
     args = parser.parse_args()
 
     client = Client(
@@ -103,7 +104,7 @@ if __name__ == "__main__":
     scim = SCIMClient(client, resource_types=(User, Group))
     results = check_server(scim)
     for result in results:
-        print(result.status.name, result.title)
+        print(result.format_status(args.no_color), result.title)
         if result.reason:
             print("  ", result.reason)
             if args.verbose and result.data:

--- a/scim2_tester/utils.py
+++ b/scim2_tester/utils.py
@@ -10,6 +10,13 @@ class Status(Enum):
     SUCCESS = auto()
     ERROR = auto()
 
+_color_by_status = {
+    # Green for success
+    Status.SUCCESS: "\033[32m",
+    # Red for error
+    Status.ERROR: "\033[31m",
+}
+
 
 @dataclass
 class CheckResult:
@@ -28,6 +35,11 @@ class CheckResult:
 
     data: Optional[Any] = None
     """Any related data that can help to debug."""
+
+    def format_status(self, no_color: bool = False):
+        if no_color:
+            return self.status.name
+        return f"{_color_by_status[self.status]}{self.status.name}\033[0m"
 
 
 def decorate_result(func):


### PR DESCRIPTION
## Context

When running the checker (as a human), it is hard to read the output.

## Proposed solution

- By default, colorize the status (ERROR in red, SUCCESS in green)
- Add the `--no-color` option to disable it (for instance in CI when they don't support termcolors)